### PR TITLE
Add gitlab streaks 1 to implement 4

### DIFF
--- a/src/intel/utils/UtilsGitlab/index.js
+++ b/src/intel/utils/UtilsGitlab/index.js
@@ -200,7 +200,9 @@ const fillStreaks = (contribs) => {
         }
       }
       else if(count > 0) {
-        const statisticId = db.exec(`SELECT id FROM statistic WHERE year=${new Date(dateFrom).getFullYear()}`).pop()["id"];
+        const statisticId = db.exec(`SELECT id FROM statistic WHERE year=${new Date(dateFrom)
+          .getFullYear()}`)
+          .pop()["id"];
         db.exec(insert.streak, [
           new Date(dateFrom),
           new Date(uniqueContribs[i-1].datetime.toISOString().split("T")[0]),

--- a/src/intel/utils/UtilsGitlab/index.js
+++ b/src/intel/utils/UtilsGitlab/index.js
@@ -202,11 +202,12 @@ const fillCalendar = async (user) => {
       let weekday = datetime.getDay().toString();
 
       const platformId = db.exec("SELECT id FROM platform").pop()["id"];
-      const statYear = db.exec("SELECT year FROM statistic").pop();
-
+      const statYears = db.exec("SELECT year FROM statistic");
       let year = datetime.getFullYear();
 
-      if(!statYear){
+      const uniqueYears = Array.from(new Set(statYears.map(a => a.year)))
+      
+      if(!uniqueYears.includes(year)) {
         db.exec(insert.statistic, [year,platformId]);
       }
 

--- a/src/intel/utils/UtilsGitlab/index.js
+++ b/src/intel/utils/UtilsGitlab/index.js
@@ -178,16 +178,15 @@ const fillContribution = (user, item) => {
 
 const fillStreaks = (contribs) => {
   contribs.sort((a,b) => (a.datetime > b.datetime) ? 1 : -1);
-  const uniqueContribs = Array.from(new Set(contribs.map(a => a.datetime.toISOString().split("T")[0])))
-  .map(datetime => {
-    return contribs.find(a => a.datetime.toISOString().split("T")[0] === datetime)
+  const uniqueContribs = Array.from(new Set(contribs.map((a) => a.datetime.toISOString().split("T")[0])))
+  .map((datetime) => {
+    return contribs.find((a) => a.datetime.toISOString().split("T")[0] === datetime);
   });
   let streak = false;
   let count;
   let dateFrom;
   for(let i = 0; i < uniqueContribs.length; i++) {
-    console.log(uniqueContribs[i].datetime.toISOString().split("T")[0])
-    const prevDay = new Date(uniqueContribs[i].datetime.getTime() - 24 * 60 * 60 * 1000).toISOString().split("T")[0]
+    const prevDay = new Date(uniqueContribs[i].datetime.getTime() - 24 * 60 * 60 * 1000).toISOString().split("T")[0];
     if(i>0) {
       if(prevDay === uniqueContribs[i-1].datetime.toISOString().split("T")[0]) {
         if(!streak){
@@ -215,7 +214,7 @@ const fillStreaks = (contribs) => {
       }
     }
   }
-}
+};
 
 const fillCalendar = async (user) => {
   const limit = "2147483647";
@@ -246,7 +245,7 @@ const fillCalendar = async (user) => {
       const statYears = db.exec("SELECT year FROM statistic");
       let year = datetime.getFullYear();
 
-      const uniqueYears = Array.from(new Set(statYears.map(a => a.year)))
+      const uniqueYears = Array.from(new Set(statYears.map((a) => a.year)));
       
       if(!uniqueYears.includes(year)) {
         db.exec(insert.statistic, [year,platformId]);

--- a/src/intel/utils/UtilsGitlab/index.js
+++ b/src/intel/utils/UtilsGitlab/index.js
@@ -164,6 +164,7 @@ const fillContribution = (user, item) => {
 
   const repository = fillRepositories(user, nameWithOwner);
   const calendarId = db.exec("SELECT id FROM calendar").pop()["id"];
+
   db.exec(insert.contrib, [
     datetime,
     nameWithOwner,
@@ -178,13 +179,16 @@ const fillContribution = (user, item) => {
 
 const fillStreaks = (contribs) => {
   contribs.sort((a,b) => (a.datetime > b.datetime) ? 1 : -1);
+
   const uniqueContribs = Array.from(new Set(contribs.map((a) => a.datetime.toISOString().split("T")[0])))
   .map((datetime) => {
     return contribs.find((a) => a.datetime.toISOString().split("T")[0] === datetime);
   });
+
   let streak = false;
   let count;
   let dateFrom;
+
   for(let i = 0; i < uniqueContribs.length; i++) {
     const prevDay = new Date(uniqueContribs[i].datetime.getTime() - 24 * 60 * 60 * 1000).toISOString().split("T")[0];
     if(i>0) {
@@ -202,12 +206,14 @@ const fillStreaks = (contribs) => {
         const statisticId = db.exec(`SELECT id FROM statistic WHERE year=${new Date(dateFrom)
           .getFullYear()}`)
           .pop()["id"];
+
         db.exec(insert.streak, [
           new Date(dateFrom),
           new Date(uniqueContribs[i-1].datetime.toISOString().split("T")[0]),
           count,
           statisticId
         ]);
+
         streak = false;
         count = 0;
         dateFrom = null;


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- Currently only one year gets filled into the statistic table. #110
- Currently there is no way to get streaks from GitLab. #111

**What is the new behavior (if this is a feature change)?**
- Now every year is filled in the statistic table. Closes #110
- Now GitLab streaks can be stored. Closes #111


**Other information**:
- Ref: #143 The quality of the branch implement-1 is not sufficient.

